### PR TITLE
Support "content_subtype" EmailMultiAlternatives when use dict in serialization

### DIFF
--- a/django_q_email/utils.py
+++ b/django_q_email/utils.py
@@ -20,6 +20,7 @@ def to_dict(email_message):
     }
     if isinstance(email_message, EmailMultiAlternatives):
         email_message_data['alternatives'] = email_message.alternatives
+        email_message_data['content_subtype'] = getattr(email_message, 'content_subtype', None)
     return email_message_data
 
 
@@ -30,6 +31,10 @@ def from_dict(email_message_data):
     """
     kwargs = dict(email_message_data)
     alternatives = kwargs.pop('alternatives', None)
-    return (
+    content_subtype = kwargs.pop('content_subtype', None)
+    email = (
         EmailMessage(**kwargs) if not alternatives else
         EmailMultiAlternatives(alternatives=alternatives, **kwargs))
+    if content_subtype:
+        email.content_subtype = content_subtype
+    return email


### PR DESCRIPTION
According with Django documentation:
https://docs.djangoproject.com/en/3.2/topics/email/#sending-alternative-content-types

> By default, the MIME type of the body parameter in an EmailMessage is "text/plain". It is good practice to leave this alone, because it guarantees that any recipient will be able to read the email, regardless of their mail client. However, if you are confident that your recipients can handle an alternative content type, you can use the content_subtype attribute on the EmailMessage class to change the main content type. The major type will always be "text", but you can change the subtype

With this pull request we add **content_subtype** in _to_dict_ and _from_dict_ utils function to handle different content type when using **DJANGO_Q_EMAIL_USE_DICTS** is True.